### PR TITLE
Use older named notation in pingest.pl

### DIFF
--- a/perl/pingest.pl
+++ b/perl/pingest.pl
@@ -236,7 +236,7 @@ sub browse_ingest {
     } elsif ($pid == 0) {
         my $dbh = DBI->connect("DBI:Pg:database=$db_db;host=$db_host;port=$db_port;application_name=pingest",
                                $db_user, $db_password);
-        my $sth = $dbh->prepare('SELECT metabib.reingest_metabib_field_entries(bib_id => ?, skip_facet => TRUE, skip_browse => FALSE, skip_search => TRUE)');
+        my $sth = $dbh->prepare('SELECT metabib.reingest_metabib_field_entries(bib_id := ?, skip_facet := TRUE, skip_browse := FALSE, skip_search := TRUE)');
         foreach (@list) {
             if ($sth->execute($_)) {
                 my $crap = $sth->fetchall_arrayref();
@@ -278,7 +278,7 @@ sub reingest {
 sub reingest_field_entries {
     my $dbh = shift;
     my $list = shift;
-    my $sth = $dbh->prepare('SELECT metabib.reingest_metabib_field_entries(bib_id => ?, skip_facet => ?, skip_browse => TRUE, skip_search => ?)');
+    my $sth = $dbh->prepare('SELECT metabib.reingest_metabib_field_entries(bib_id := ?, skip_facet := ?, skip_browse := TRUE, skip_search := ?)');
     # Because reingest uses "skip" options we invert the logic of do variables.
     $sth->bind_param(2, ($skip_facets) ? 1 : 0);
     $sth->bind_param(3, ($skip_search) ? 1 : 0);
@@ -297,7 +297,7 @@ sub reingest_attributes {
     my $dbh = shift;
     my $list = shift;
     my $sth = $dbh->prepare(<<END_OF_INGEST
-SELECT metabib.reingest_record_attributes(rid => id, prmarc => marc)
+SELECT metabib.reingest_record_attributes(rid := id, prmarc := marc)
 FROM biblio.record_entry
 WHERE id = ?
 END_OF_INGEST


### PR DESCRIPTION
Use older style param := 'value' named notation for PostgreSQL
function calls in pingest.pl to support PostgreSQL versions < 9.5.

Signed-off-by: Jeff Godin <jgodin@tadl.org>